### PR TITLE
Fix WeylChamber.ticklabelsize

### DIFF
--- a/src/weylchamber/visualize.py
+++ b/src/weylchamber/visualize.py
@@ -319,9 +319,9 @@ class WeylChamber():
         ax.yaxis.set_ticklabels(['0', '', '', '', '', r'$\pi/2$'])
         ax.zaxis.set_ticks([0, 0.1, 0.2, 0.3, 0.4, 0.5])
         ax.zaxis.set_ticklabels(['0', '', '', '', '', r'$\pi/2$'])
-        ax.tick_params(axis='x', pad=self.c1_tickspad)
-        ax.tick_params(axis='y', pad=self.c2_tickspad)
-        ax.tick_params(axis='z', pad=self.c2_tickspad)
+        ax.tick_params(axis='x', pad=self.c1_tickspad, labelsize=self.ticklabelsize)
+        ax.tick_params(axis='y', pad=self.c2_tickspad, labelsize=self.ticklabelsize)
+        ax.tick_params(axis='z', pad=self.c2_tickspad, labelsize=self.ticklabelsize)
         [t.set_va('center') for t in ax.get_yticklabels()]
         [t.set_ha('left') for t in ax.get_yticklabels()]
         [t.set_va('center') for t in ax.get_zticklabels()]

--- a/src/weylchamber/visualize.py
+++ b/src/weylchamber/visualize.py
@@ -50,9 +50,6 @@ class WeylChamber():
         elevation view angle in degrees
     dpi: int {300}
         Resolution to use when saving to dpi, or showing interactively
-    linecolor: str {'black'}
-        Color to be used when drawing lines (e.g. the edges of the Weyl
-        chamber)
     show_c1_label: bool
         Whether or not to show the c1 axis label
     show_c2_label: bool
@@ -141,7 +138,6 @@ class WeylChamber():
         self.bottom_margin =  0.0
         self.right_margin =  0.3
         self.top_margin =  0.0
-        self.linecolor = 'black'
         self.show_c1_label = True
         self.show_c2_label = True
         self.show_c3_label = True


### PR DESCRIPTION
This PR includes a minor addition to the existing `ax.tick_params` call to also make use of the member `WeylChamber.ticklabelsize` which is already defined but never used.

Additionally, I removed the member `linecolor` which seems to be never used and is less powerful than the members `weyl_edge_fg_properties`, `weyl_edge_bg_properties`, `PE_edge_fg_properties` and `PE_edge_bg_properties`.